### PR TITLE
#310: Fixed `SqlStatementSelect.Builder.build()` so empty and partial builders no longer fail with NullPointerException

### DIFF
--- a/doc/changes/changes_18.0.2.md
+++ b/doc/changes/changes_18.0.2.md
@@ -9,11 +9,13 @@ Code name: Improve code quality
 * `Capabilities.subtractCapabilities()` is now deprecated for removal and delegates to the new pure `Capabilities.subtract()` implementation. Code that relied on the previous side effect of mutating the receiver must be adapted (#305).
 * Constructor `ColumnMetadata.Builder()` is now deprecated for removal. Use `ColumnMetadata.builder()` to create a new instance (#306).
 * Constructor `Capabilities.Builder()` is now deprecated for removal. Use `Capabilities.builder()` to create a new instance (#305).
+* Constructor `SqlStatementSelect.Builder()` is now deprecated for removal. Use `SqlStatementSelect.builder()` to create a new instance (#306).
 
 ## Bugfixes
 
 * #305: Fixed `Capabilities.subtractCapabilities()` so it no longer mutates the receiver. Added the pure `Capabilities.subtract()` method.
 * #306: Fixed `TablesMetadataParser` so omitted `isIdentity` values default to `false` while omitted `isNullable` values still default to `true`.
+* #310: Fixed `SqlStatementSelect.Builder.build()` so empty and partial builders no longer fail with a raw `NullPointerException`.
 
 ## Dependency Updates
 

--- a/src/main/java/com/exasol/adapter/sql/SqlStatementSelect.java
+++ b/src/main/java/com/exasol/adapter/sql/SqlStatementSelect.java
@@ -1,9 +1,9 @@
 package com.exasol.adapter.sql;
 
-import com.exasol.adapter.AdapterException;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.exasol.adapter.AdapterException;
 
 /**
  * We could consider to apply builder pattern here (if time)
@@ -25,8 +25,12 @@ public class SqlStatementSelect extends SqlStatement {
         this.having = builder.having;
         this.orderBy = builder.orderBy;
         this.limit = builder.limit;
-        this.fromClause.setParent(this);
-        this.selectList.setParent(this);
+        if (this.fromClause != null) {
+            this.fromClause.setParent(this);
+        }
+        if (this.selectList != null) {
+            this.selectList.setParent(this);
+        }
 
         if (this.whereClause != null) {
             this.whereClause.setParent(this);
@@ -177,6 +181,7 @@ public class SqlStatementSelect extends SqlStatement {
      *
      * @return builder instance
      */
+    @SuppressWarnings("removal")
     public static Builder builder() {
         return new Builder();
     }
@@ -192,6 +197,14 @@ public class SqlStatementSelect extends SqlStatement {
         private SqlNode having;
         private SqlOrderBy orderBy;
         private SqlLimit limit;
+
+        /**
+         * @deprecated use {@link #builder()} instead
+         */
+        @Deprecated(since = "18.0.2", forRemoval = true)
+        public Builder() {
+            // empty constructor
+        }
 
         /**
          * Set the from clause of the SQL Select Statement.
@@ -284,7 +297,7 @@ public class SqlStatementSelect extends SqlStatement {
     public List<SqlNode> getChildren() {
         // This method is not super efficient, but it is not used at the moment and needed
         // only for consistency with SqlNode interface.
-        ArrayList<SqlNode> children = new ArrayList<>();
+        final List<SqlNode> children = new ArrayList<>();
         if (this.fromClause != null) {
             children.add(this.fromClause);
         }

--- a/src/test/java/com/exasol/adapter/sql/SqlStatementSelectTest.java
+++ b/src/test/java/com/exasol/adapter/sql/SqlStatementSelectTest.java
@@ -1,7 +1,11 @@
 package com.exasol.adapter.sql;
 
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.Test;
@@ -53,5 +57,31 @@ class SqlStatementSelectTest {
 
         assertThat(fromClause.getParent(), sameInstance(select));
         assertThat(selectList.getParent(), sameInstance(select));
+    }
+
+    @Test
+    void getChildrenReturnsEmptyListForEmptyBuilder() {
+        final SqlStatementSelect select = SqlStatementSelect.builder().build();
+
+        assertThat(select.getChildren(), empty());
+    }
+
+    @Test
+    void getChildrenReturnsChildrenInClauseOrder() {
+        final SqlTable fromClause = new SqlTable("MY_TABLE", null);
+        final SqlLiteralBool projectedColumn = new SqlLiteralBool(true);
+        final SqlSelectList selectList = SqlSelectList.createRegularSelectList(List.of(projectedColumn));
+        final SqlLiteralBool whereClause = new SqlLiteralBool(false);
+        final SqlLiteralBool groupByExpression = new SqlLiteralBool(true);
+        final SqlGroupBy groupBy = new SqlGroupBy(List.of(groupByExpression));
+        final SqlLiteralBool having = new SqlLiteralBool(true);
+        final SqlLiteralBool orderByExpression = new SqlLiteralBool(false);
+        final SqlOrderBy orderBy = new SqlOrderBy(List.of(orderByExpression), List.of(true), List.of(true));
+        final SqlLimit limit = new SqlLimit(10);
+        final SqlStatementSelect select = SqlStatementSelect.builder().fromClause(fromClause).selectList(selectList)
+                .whereClause(whereClause).groupBy(groupBy).having(having).orderBy(orderBy).limit(limit).build();
+
+        assertThat(select.getChildren(), contains(fromClause, projectedColumn, whereClause, groupByExpression, having,
+                orderByExpression, limit));
     }
 }

--- a/src/test/java/com/exasol/adapter/sql/SqlStatementSelectTest.java
+++ b/src/test/java/com/exasol/adapter/sql/SqlStatementSelectTest.java
@@ -1,14 +1,57 @@
 package com.exasol.adapter.sql;
 
-import org.junit.jupiter.api.Test;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
 
 class SqlStatementSelectTest {
     @Test
     void builder() {
         final SqlStatementSelect.Builder sqlStatementSelectBuilder = SqlStatementSelect.builder();
         assertThat(sqlStatementSelectBuilder, instanceOf(SqlStatementSelect.Builder.class));
+    }
+
+    @Test
+    void buildWithoutRequiredClausesDoesNotThrow() {
+        final SqlStatementSelect select = assertDoesNotThrow(() -> SqlStatementSelect.builder().build());
+
+        assertThat(select.getFromClause(), nullValue());
+        assertThat(select.getSelectList(), nullValue());
+    }
+
+    @Test
+    void buildWithOnlyFromClauseDoesNotThrow() {
+        final SqlTable fromClause = new SqlTable("MY_TABLE", null);
+
+        final SqlStatementSelect select = assertDoesNotThrow(
+                () -> SqlStatementSelect.builder().fromClause(fromClause).build());
+
+        assertThat(select.getFromClause(), sameInstance(fromClause));
+        assertThat(select.getSelectList(), nullValue());
+    }
+
+    @Test
+    void buildWithOnlySelectListDoesNotThrow() {
+        final SqlSelectList selectList = SqlSelectList.createAnyValueSelectList();
+
+        final SqlStatementSelect select = assertDoesNotThrow(
+                () -> SqlStatementSelect.builder().selectList(selectList).build());
+
+        assertThat(select.getFromClause(), nullValue());
+        assertThat(select.getSelectList(), sameInstance(selectList));
+    }
+
+    @Test
+    void buildSetsParentForPresentRequiredClauses() {
+        final SqlTable fromClause = new SqlTable("MY_TABLE", null);
+        final SqlSelectList selectList = SqlSelectList.createAnyValueSelectList();
+
+        final SqlStatementSelect select = SqlStatementSelect.builder().fromClause(fromClause).selectList(selectList)
+                .build();
+
+        assertThat(fromClause.getParent(), sameInstance(select));
+        assertThat(selectList.getParent(), sameInstance(select));
     }
 }


### PR DESCRIPTION
Closes #310